### PR TITLE
Refactor collectibles and platforms to their own classes

### DIFF
--- a/src/game/scenes/Collectibles.js
+++ b/src/game/scenes/Collectibles.js
@@ -1,0 +1,37 @@
+export class Collectibles {
+    constructor(scene) {
+        this.scene = scene
+        this.group = this.scene.physics.add.group({
+            key: 'coffee',
+            repeat: 11,
+            setXY: { x: 20, y: 0, stepX: 69 }
+        })
+        this.init()
+    }
+
+    init() {
+        this.group.children.iterate(function (child) {
+            child.setBounceY(Phaser.Math.FloatBetween(0.4, 0.8))
+        })
+    }
+
+    reset() {
+        if (this.group.countActive(true) === 0) {
+            this.group.children.iterate((child) => {
+                child.enableBody(true, child.x, 0, true, true)
+            })
+        }
+    }
+
+    collect = (player, collectible) => {
+        collectible.disableBody(true, true)
+
+        this.scene.updateScore(10)
+
+        if (this.group.countActive(true) === 0) {
+            this.reset()
+
+            this.scene.levelUp()
+        }
+    }
+}

--- a/src/game/scenes/Level.js
+++ b/src/game/scenes/Level.js
@@ -21,8 +21,7 @@ export class Level extends Scene {
     collectCollectible = (player, collectible) => {
         collectible.disableBody(true, true)
 
-        this.score += 10
-        this.scoreText.setText('Score: ' + this.score)
+        this.updateScore(10)
 
         if (this.collectibles.countActive(true) === 0) {
             this.collectibles.children.iterate((child) => {
@@ -41,8 +40,6 @@ export class Level extends Scene {
     gameOver = () => {
         this.physics.pause()
 
-        this.score = 0
-
         this.player.kill()
 
         this.add.text(400, 300, 'Game Over', {
@@ -56,14 +53,15 @@ export class Level extends Scene {
         })
 
         this.input.keyboard.once('keyup-SPACE', (event) => {
-            this.scene.start(scenes.title)
+            this.scene.restart(scenes.title)
         })
     }
 
     create = () => {
         this.add.image(400, 300, 'sky')
 
-        this.scoreText = this.add.text(16, 16, 'score: 0', { fontSize: '32px', fill: '#000' })
+        this.score = 0
+        this.scoreText = this.add.text(16, 16, 'Score: 0', { fontSize: '32px', fill: '#000' })
 
         this.player = new Player(this, 100, 450)
 
@@ -118,8 +116,14 @@ export class Level extends Scene {
         this.platforms.create(750, 220, 'ground')
     }
 
-    initAnimations = () =>
-        Object.values(animations).forEach((animation) => this.anims.create(animation))
+    initAnimations = () => {
+        Object.values(animations).forEach((animation) => {
+            // Animations are globally scoped, so check if it exists first
+            if (!this.anims.exists(animation.key)) {
+                this.anims.create(animation)
+            }
+        })
+    }
 
     initCollectibles = () => {
         this.collectibles = this.physics.add.group({
@@ -131,5 +135,10 @@ export class Level extends Scene {
         this.collectibles.children.iterate(function (child) {
             child.setBounceY(Phaser.Math.FloatBetween(0.4, 0.8))
         })
+    }
+
+    updateScore = (points) => {
+        this.score += points
+        this.scoreText.setText('Score: ' + this.score)
     }
 }

--- a/src/game/scenes/Platforms.js
+++ b/src/game/scenes/Platforms.js
@@ -1,0 +1,30 @@
+export class Platforms {
+    constructor(scene) {
+        this.scene = scene
+        this.group = this.scene.physics.add.staticGroup()
+        this.init()
+    }
+
+    init(level = 1) {
+        this.clearPlatforms()
+
+        switch (level) {
+            case 1:
+                // ground
+                this.group.create(400, 568, 'ground').setScale(2).refreshBody()
+                // lower level
+                this.group.create(612, 400, 'ground')
+                // mid level
+                this.group.create(50, 250, 'ground')
+                // upper level
+                this.group.create(750, 220, 'ground')
+                break
+            default:
+                break
+        }
+    }
+
+    clearPlatforms() {
+        this.group.clear(true, true)
+    }
+}


### PR DESCRIPTION
- Introduce classes to manage collectibles and platforms separately
- Small tweak to coffee cup placement (so they are not clipped at the edges) and platform sizing (for consistency of cup placement)

Coffee cups before:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/fd0a962e-f508-4e14-bd89-30b3044133c9">

After:
<img width="337" alt="image" src="https://github.com/user-attachments/assets/40761d7e-5b67-4ac9-94ed-a9e7f2da1a7d">

Platform before:
<img width="482" alt="image" src="https://github.com/user-attachments/assets/67b79785-0aaa-469e-be6d-f8227e371195">

After:
<img width="458" alt="image" src="https://github.com/user-attachments/assets/b7514713-c696-4135-9add-54c4a6275f4a">
